### PR TITLE
version bumps and new gradlew command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM java:7
 
 RUN apt-get update && apt-get install -y wget unzip
 
-ENV VOLDEMORT_VERSION=release-1.9.17-cutoff
+ENV VOLDEMORT_VERSION=release-1.10.17-cutoff
 RUN wget https://github.com/voldemort/voldemort/archive/$VOLDEMORT_VERSION.zip
 RUN unzip $VOLDEMORT_VERSION.zip && mv voldemort-* voldemort
 
 WORKDIR /voldemort/
 
 ENV VOLDEMORT_HOME /voldemort/config/single_node_cluster
-RUN ./gradlew clean jar
+RUN ./gradlew clean build -x test
 
 EXPOSE 6666 6667 8081
 


### PR DESCRIPTION
Hi @daniellawrence ,

Thanks for the repo. I've updated the `gradelw` command to reflect new documentation and given a version bump for the default voldemort version. Feel free to accept or reject. Just thought I'd throw this out there to save some time for new users.
